### PR TITLE
Made JdbcCoherentParamCache initializable.

### DIFF
--- a/smartparam-coherent-cache-jdbc/src/main/java/org/smartparam/coherence/jdbc/cache/JdbcCoherentParamCache.java
+++ b/smartparam-coherent-cache-jdbc/src/main/java/org/smartparam/coherence/jdbc/cache/JdbcCoherentParamCache.java
@@ -1,6 +1,7 @@
 package org.smartparam.coherence.jdbc.cache;
 
-import org.smartparam.coherence.jdbc.repository.ParamVersionRepository;
+import org.smartparam.coherence.jdbc.repository.JdbcParamVersionRepository;
+import org.smartparam.engine.config.initialization.InitializableComponent;
 import org.smartparam.engine.core.prepared.PreparedParamCache;
 import org.smartparam.engine.core.prepared.PreparedParameter;
 
@@ -8,15 +9,15 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
-public class JdbcCoherentParamCache implements CoherentParamCache {
+public class JdbcCoherentParamCache implements CoherentParamCache, InitializableComponent {
 
     private PreparedParamCache decoratedCache;
 
-    private ParamVersionRepository versionRepository;
+    private JdbcParamVersionRepository versionRepository;
 
     private Map<String, Long> localVersions = new HashMap<String, Long>();
 
-    public JdbcCoherentParamCache(PreparedParamCache decoratedCache, ParamVersionRepository versionRepository) {
+    public JdbcCoherentParamCache(PreparedParamCache decoratedCache, JdbcParamVersionRepository versionRepository) {
         this.decoratedCache = decoratedCache;
         this.versionRepository = versionRepository;
     }
@@ -63,5 +64,10 @@ public class JdbcCoherentParamCache implements CoherentParamCache {
     @Override
     public Collection<String> cachedParameterNames() {
         return decoratedCache.cachedParameterNames();
+    }
+
+    @Override
+    public void initialize() {
+        versionRepository.initialize();
     }
 }

--- a/smartparam-coherent-cache-jdbc/src/test/java/org/smartparam/coherence/jdbc/cache/JdbcCoherentParamCacheTest.java
+++ b/smartparam-coherent-cache-jdbc/src/test/java/org/smartparam/coherence/jdbc/cache/JdbcCoherentParamCacheTest.java
@@ -1,5 +1,6 @@
 package org.smartparam.coherence.jdbc.cache;
 
+import org.smartparam.coherence.jdbc.repository.JdbcParamVersionRepository;
 import org.smartparam.coherence.jdbc.repository.ParamVersionRepository;
 import org.smartparam.engine.cache.MapPreparedParamCache;
 import org.smartparam.engine.core.prepared.PreparedParameter;
@@ -14,13 +15,13 @@ import static org.smartparam.engine.core.prepared.PreparedParameterTestBuilder.p
 
 public class JdbcCoherentParamCacheTest {
 
-    private ParamVersionRepository versionRepository;
+    private JdbcParamVersionRepository versionRepository;
 
     private CoherentParamCache coherentCache;
 
     @BeforeMethod
     public void setUp() {
-        versionRepository = mock(ParamVersionRepository.class);
+        versionRepository = mock(JdbcParamVersionRepository.class);
         coherentCache = new JdbcCoherentParamCache(new MapPreparedParamCache(), versionRepository);
     }
 


### PR DESCRIPTION
Makes param version schema to be created when constructing ParamEngine through ParamEngineFactory.
